### PR TITLE
Add IKEA manuals link and BOGO SÖRT image

### DIFF
--- a/src/content/docs/Courses/cse-310.mdx
+++ b/src/content/docs/Courses/cse-310.mdx
@@ -34,6 +34,9 @@ These are some of the tools that are useful for this course (contributions welco
 - [ASU Linux Environment](https://fpsluozi.github.io/Linux-Setup/) - Free CLI access to computers with Linux environment to compile and run code.
 - [Heap Visualization](https://www.cs.usfca.edu/~galles/visualization/Heap.html)
 - [DSA Visualization](https://www.cs.usfca.edu/~galles/visualization/Algorithms.html)
+- [IKEA manuals for different algorithms](https://idea-instructions.com) - a fun way of getting more intuition for common algos, all without words. here's [BOGO SÖRT](https://idea-instructions.com/bogo-sort/) for example (check out [KVICK SÖRT](https://idea-instructions.com/quick-sort/) and [MERGE SÖRT](https://idea-instructions.com/merge-sort/) too!:
+
+![bogo sort](https://idea-instructions.com/bogo-sort.png)
 
 ### Student Reviews
 


### PR DESCRIPTION

## Description

Added a link to IKEA manuals for algorithms and included an image for BOGO SÖRT.

## Type of Change
- [X] Content update (course info, guides, resources)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
- [ ] Tested locally
- [X] Verified all links work
- [ ] Checked mobile responsiveness (if applicable)