### PR TITLE
feat: add maximizing free AI guide for ASU students

### DIFF
--- a/src/content/docs/Guides/Maximizing Free AI as ASU Student.mdx
+++ b/src/content/docs/Guides/Maximizing Free AI as ASU Student.mdx
@@ -1,0 +1,38 @@
+---
+title: Maximizing Free AI as ASU Student
+description: A guide to unlocking free AI subscriptions with your ASU email and student status | The ASU CS Wiki
+---
+
+Being a student at ASU comes with a surprising number of free premium AI subscriptions. This guide covers how to get the most out of your student status.
+
+## Free Subscriptions
+- **ChatGPT Edu via [ai.asu.edu/chatgpt-edu](https://ai.asu.edu/chatgpt-edu)**
+    - Best way to use Codex and ChatGPT
+- **Claude Pro via [claudebuilder.club](https://www.claudebuilder.club)**
+    - Best way to use Claude Opus
+    - Claude models are amazing for writing and have the most human tone
+    - Also not as syncophantic as OpenAI models
+- **Gemini Pro [instructions](https://support.google.com/gemini/answer/16417758?hl=en)**
+    - Best way to use Gemini Pro
+    - Great for managing Google Calendar, like pasting in screenshots of events and having it create calendar events
+    - You can also use the Antigravity IDE with this subscription
+- **GitHub Copilot via [GitHub Student Developer Pack](https://education.github.com/pack)**
+    - Comes with Copilot tab-complete and agent mode in VS Code
+    - You can also spawn background web coding agents at [github.com/copilot](https://github.com/copilot)
+- **JetBrains via [GitHub Student Developer Pack](https://education.github.com/pack)**
+    - Comes with AI Assistant too
+    - IDEs are some of the most powerful you can get---the refactoring facilities are best-in-class
+    - Quite resource-intensive IDEs, though
+- **And more via [GitHub Student Developer Pack](https://education.github.com/pack)**
+    - There's also a bunch of other cool things you can get with the pack. Scroll through and shop around!
+- **Cursor via [cursor.com/students](https://cursor.com/students)**
+    - Free Pro for a year with a `.edu` email
+- **Windsurf via [windsurf.com/editor/students](https://windsurf.com/editor/students)**
+    - AI-powered code editor with a free tier (25 credits/month)
+    - Students get over 50% off a Pro subscription with a `.edu` email
+- **Zed via [zed.dev/education](https://zed.dev/education)**
+    - Free Pro for one year for verified university students
+    - Includes $10/month in token credits for AI assistance, unlimited edit predictions, and real-time multiplayer collaboration
+    - *Very fast editor, most recommended by the SoDA Technology Team* 😉
+- **LM Arena via [arena.ai/code/direct](https://arena.ai/code/direct)**
+    - Chat directly with leading coding AI models and compare outputs side-by-side

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -53,8 +53,13 @@ import { ContributorList } from "starlight-contributor-list";
 		title="Campus Resources"
 		icon="open-book"
 		href="/guides/campus-resources"
-		description="Find research positions, faculty projects, and undergraduate research programs to gain hands-on experience in cutting-edge technology."
-    	description="Essential campus services including dining, health services, 3D printing, makerspace access, and emergency contacts all in one place."
+		description="Essential campus services including dining, health services, 3D printing, makerspace access, and emergency contacts all in one place."
+	/>
+	<IconLinkCard
+		title="Maximizing Free AI as ASU Student"
+		icon="laptop"
+		href="/guides/maximizing-free-ai-as-asu-student"
+		description="How to get ChatGPT Edu, Claude Pro, Copilot, Cursor, and more with your ASU email."
 	/>
 </CardGrid>
 


### PR DESCRIPTION
## Summary

Adds a new wiki guide page that compiles all the free AI tools and subscriptions available to ASU students, along with relevant signup links.

## Changes

- **New page**: `src/content/docs/Guides/Maximizing Free AI as ASU Student.mdx`
  - ChatGPT Edu (via ASURite)
  - Claude Pro (via claudebuilder.club)
  - Gemini Pro (via ASURite)
  - GitHub Copilot & JetBrains (via GitHub Student Developer Pack)
  - Cursor (free Pro for 1 year)
  - Windsurf (discounted Pro)
  - Zed (free Pro for 1 year — *most recommended by SoDA Technology Team*)
  - LM Arena
- **Homepage update**: Added `IconLinkCard` in `src/content/docs/index.mdx` linking to the new guide