### PR TITLE
Add SoDA guides and workshop notes

### DIFF
--- a/src/content/docs/Guides/AI and LLM Projects.mdx
+++ b/src/content/docs/Guides/AI and LLM Projects.mdx
@@ -1,0 +1,145 @@
+---
+title: AI and LLM Projects
+description: Notes from SoDA LLM API and AI-in-coding workshops.
+---
+
+AI tools are useful, but they do not remove the need to understand software engineering. The strongest students use AI as a force multiplier: faster exploration, faster boilerplate, faster debugging, but still human-owned architecture, validation, and judgment.
+
+## example project: multimodal note summarizer
+
+One SoDA LLM API workshop used a note summarizer as the example project.
+
+Inputs:
+
+- Plain text notes
+- DOCX files
+- PDF files
+
+Process:
+
+- Extract text from the uploaded file.
+- Send the content to an LLM API.
+- Ask for clear bullet-point summaries or study-guide output.
+
+Output:
+
+- A concise summary displayed in a web app.
+- Optional variants like different voices, study guides, or image support.
+
+## quick stack
+
+The workshop used:
+
+- Python for application logic
+- Streamlit for the web UI
+- Google Gemini API for generation
+- `python-docx` for DOCX parsing
+- `PyPDF2` or similar tools for PDF parsing
+- `python-dotenv` for local secrets
+
+The basic setup:
+
+```bash
+pip install streamlit python-docx PyPDF2 google-generativeai python-dotenv
+```
+
+Store API keys in `.env`, then add `.env` to `.gitignore`.
+
+## streamlit basics
+
+Streamlit lets you build simple web apps without creating a separate frontend.
+
+Common UI calls:
+
+```python
+st.title("Title")
+st.header("Header")
+st.subheader("Subheader")
+st.write("Text or data")
+st.text_input("Enter your name")
+st.text_area("Paste notes")
+st.file_uploader("Upload a file", type=["txt", "docx", "pdf"])
+```
+
+Run a Streamlit app with:
+
+```bash
+streamlit run app.py
+```
+
+## file handling
+
+Uploaded files include a MIME type that helps determine how to parse them.
+
+Examples:
+
+- DOCX: `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- PDF: `application/pdf`
+- PNG: `image/png`
+
+Use the MIME type to route the file to the right extraction function.
+
+## prompt design
+
+For a summarizer, be specific about output shape:
+
+```text
+Summarize these notes for a college student.
+Return:
+1. Five key ideas
+2. Important definitions
+3. Likely exam questions
+4. A short study plan
+```
+
+Good prompts define:
+
+- Audience
+- Task
+- Format
+- Constraints
+- Tone
+- What to do when the input is missing or unclear
+
+## AI-assisted coding reality check
+
+An industry talk in the workshop set emphasized that AI coding tools can accelerate development, reduce boilerplate, catch some bugs, and help migrate or explain legacy code. They still need skilled supervision.
+
+AI is good at:
+
+- Pattern recognition
+- Boilerplate generation
+- Explaining unfamiliar APIs
+- Drafting tests
+- Suggesting refactors
+- Speeding up repetitive tasks
+
+AI is weak at:
+
+- Understanding business intent
+- Owning architecture
+- Handling large cross-file context perfectly
+- Guaranteeing secure or scalable code
+- Knowing team-specific conventions
+- Replacing human judgment
+
+## risks to watch
+
+- Generated code may be inefficient, outdated, insecure, or subtly wrong.
+- Models inherit both good and bad habits from public training data.
+- AI can create a false sense of correctness when outputs look polished.
+- Productivity gains often raise expectations rather than reduce workload.
+- More time may shift into reviewing, debugging, prompting, and validating generated code.
+
+## skills that stay valuable
+
+- CS fundamentals and data structures
+- Architecture and system design
+- Debugging and testing
+- Security awareness
+- Code review
+- Communication and leadership
+- Domain knowledge in real industries
+
+The future is not "AI replaces engineers." It is more likely that engineers who can use AI well, validate it carefully, and connect it to real problems will have an advantage.
+

--- a/src/content/docs/Guides/Functional Programming.mdx
+++ b/src/content/docs/Guides/Functional Programming.mdx
@@ -1,0 +1,105 @@
+---
+title: Functional Programming
+description: A practical introduction to functional programming ideas from a SoDA technical talk.
+---
+
+Functional programming is useful even if you do not write Haskell, Rust, Scala, or another language associated with FP. The core ideas help you write code that is easier to test, read, parallelize, and reuse.
+
+## the mindset
+
+Functional programming emphasizes:
+
+- Functions and types over classes and class methods
+- Pure functions
+- Immutability where practical
+- Data transformations
+- Small composable pieces
+- Clear inputs and outputs
+
+You do not need to rewrite everything in a purely functional style. Even using these ideas selectively can improve everyday Java, Python, JavaScript, TypeScript, C++, or C#.
+
+## pure functions
+
+A pure function is fully described by its inputs and return value. If you call it with the same arguments, it returns the same result and does not change anything outside itself.
+
+Examples:
+
+```text
+add(1, 2) -> 3
+add(0, 140) -> 140
+add(100, -20) -> 80
+```
+
+Pure operations include arithmetic, comparisons, string length, and reading an array value.
+
+Impure operations include printing, writing files, mutating a list, reading random numbers, calling a database, or changing global state.
+
+## side effects
+
+Side effects are not always bad. Real programs need input, output, files, databases, logs, APIs, and randomness.
+
+The functional programming lesson is to quarantine side effects:
+
+- Keep business logic pure when possible.
+- Put file, network, database, and UI effects near the edges.
+- Pass data into pure functions.
+- Return new data instead of mutating hidden state.
+- Test pure functions directly.
+
+This makes the hard parts of a program easier to reason about.
+
+## functions as values
+
+Many languages let you pass functions around like values. That makes it easier to reuse behavior.
+
+```js
+const numbers = [1, 2, 3, 4];
+const doubled = numbers.map((n) => n * 2);
+```
+
+The function `(n) => n * 2` is passed into `map`.
+
+## map, filter, reduce
+
+These are common array programming tools.
+
+`map` transforms every item:
+
+```js
+const names = users.map((user) => user.name);
+```
+
+`filter` keeps only matching items:
+
+```js
+const activeUsers = users.filter((user) => user.active);
+```
+
+`reduce` combines many items into one result:
+
+```js
+const total = cart.reduce((sum, item) => sum + item.price, 0);
+```
+
+These tools are useful because they describe what transformation you want without manually managing loop state.
+
+## types matter
+
+Types help document what a function expects and returns. They catch mistakes earlier and make code easier to change.
+
+Optional types are especially useful because they force you to handle missing values explicitly instead of hoping `null` never appears.
+
+The talk referenced null as the "billion dollar mistake" because null-related errors have caused enormous real-world cost. Modern languages and type systems try to reduce those mistakes through `Optional`, `Maybe`, nullable annotations, or strict null checks.
+
+## when to use FP ideas
+
+Use functional programming ideas when:
+
+- A function is hard to test because it touches too much state.
+- Bugs come from unexpected mutation.
+- You need to transform collections of data.
+- You want logic that can run in parallel more safely.
+- You need code that is easier to review.
+
+Avoid forcing FP style when it makes simple code harder to understand. The goal is clarity, not showing off.
+

--- a/src/content/docs/Guides/Git and GitHub.mdx
+++ b/src/content/docs/Guides/Git and GitHub.mdx
@@ -1,0 +1,151 @@
+---
+title: Git and GitHub
+description: A beginner-friendly guide distilled from SoDA Git workshops.
+---
+
+Git is one of the most important tools to learn outside class. It lets you track changes, collaborate safely, recover from mistakes, and show employers that you can work like a software engineer.
+
+## git vs github
+
+Git is the version control system. It runs locally and tracks changes in a project.
+
+GitHub is a hosting service for Git repositories. It stores repositories in the cloud and adds collaboration features like issues, pull requests, code review, and project visibility.
+
+## why git matters
+
+Git helps you:
+
+- See what changed
+- See who changed it
+- See when it changed
+- Understand why it changed
+- Restore older versions
+- Work with teammates without overwriting each other
+- Review code before merging it
+
+Think of it like Google Docs version history, but designed for software projects.
+
+## core workflow
+
+```bash
+git init
+git status
+git add .
+git commit -m "Describe the change"
+git push
+git pull
+```
+
+What each command does:
+
+- `git init` creates a Git repository in a folder.
+- `git status` shows changed, staged, and untracked files.
+- `git add` stages files for the next commit.
+- `git commit` creates a snapshot of staged files.
+- `git push` sends local commits to a remote repository.
+- `git pull` brings remote changes down to your machine.
+
+Pull before pushing when collaborating so you start from the latest shared work.
+
+## commits
+
+A commit should represent a meaningful milestone. Do not wait until the entire project is perfect, but avoid committing unrelated changes together.
+
+Good commit habits:
+
+- Use short, descriptive messages.
+- Commit working checkpoints.
+- Keep unrelated changes separate.
+- Explain why a change exists when the reason is not obvious.
+- Push your branch so teammates and CI can see it.
+
+## staging
+
+Staging lets you choose what goes into a commit. This matters when you changed multiple things but only one is ready.
+
+Examples:
+
+```bash
+git add src/app.js
+git add src/app.js src/utils.js
+git add .
+```
+
+## gitignore
+
+A `.gitignore` file prevents accidental commits of files that should stay local.
+
+Common things to ignore:
+
+- `.env`
+- API keys and secrets
+- Local databases
+- Dependency folders like `node_modules`
+- Build output
+- Virtual environment folders
+
+Never commit secrets. If you do, rotate the secret instead of only deleting the file later.
+
+## branches
+
+Branches let you work on a unique set of changes without disrupting the main codebase.
+
+```bash
+git checkout -b my-feature
+git checkout main
+```
+
+Branch early and often. Branches are cheap, and they make it easier to experiment, ask for feedback, and keep work organized.
+
+## pull requests and code review
+
+A pull request asks to merge one branch into another. It gives teammates a place to review, discuss, test, and improve the change before it becomes part of the main codebase.
+
+Good pull requests:
+
+- Explain what changed
+- Explain why it changed
+- Include screenshots or test notes when relevant
+- Stay small enough to review
+- Link issues or tasks when possible
+
+## merge conflicts
+
+Merge conflicts happen when Git cannot automatically combine changes. They are normal, especially when multiple people edit the same lines.
+
+When resolving conflicts:
+
+- Pull the latest changes.
+- Read both versions carefully.
+- Keep the intended behavior from each side.
+- Run tests or manually verify after resolving.
+- Ask the teammate who wrote the other side if the conflict is unclear.
+
+## undoing changes
+
+There are multiple ways to undo changes, but shared history deserves care.
+
+`git revert` is usually safer for commits that other people may already have pulled. It creates a new commit that reverses an older one.
+
+`git reset` can rewrite history and should be used carefully, especially on shared branches.
+
+## continuous integration
+
+Continuous integration means code is built and tested frequently after commits are pushed. It helps teams catch errors earlier, reduce debugging cost, and avoid large painful merges.
+
+Common CI checks include:
+
+- Build succeeds
+- Tests pass
+- Formatting and linting pass
+- Type checks pass
+
+## github profile advice
+
+- Use the GitHub Student Developer Pack.
+- Keep class projects private if academic integrity rules require it.
+- Add READMEs to projects.
+- Pin projects that show your best work.
+- Use a profile picture and short bio.
+- Contribute consistently instead of only before recruiting season.
+

--- a/src/content/docs/Guides/Hackathons.mdx
+++ b/src/content/docs/Guides/Hackathons.mdx
@@ -1,0 +1,118 @@
+---
+title: Hackathons
+description: Practical hackathon advice from SoDA and InnovationHacks workshops.
+---
+
+Hackathons are short, intense project-building events. They are useful for learning new tools, meeting teammates, creating resume projects, and practicing how to explain technical work.
+
+## what to expect
+
+InnovationHacks was described as a two-day rapid software prototyping event with teams of two to four people and problem statements revealed at the event. Other hackathons vary, but the core pattern is similar: form a team, understand the prompt, build a prototype, and present it clearly.
+
+## team composition
+
+Choosing the right teammates matters. A strong team is not just "four coders."
+
+Look for complementary strengths:
+
+- Backend or infrastructure
+- Frontend or mobile
+- Product design
+- User experience
+- Data, AI, or domain knowledge
+- Project management
+- Pitching and storytelling
+
+Agree early on communication norms, roles, and how you will make decisions when time is short.
+
+## understand the problem first
+
+Do not jump straight into code. Use the 5Ws:
+
+- Who has the problem?
+- What job do they need done?
+- When does the problem happen?
+- Where does the solution need to work?
+- Why does this matter?
+
+Then turn needs into requirements:
+
+- What must the solution do?
+- What constraints exist?
+- What would count as success?
+- What can be safely skipped for a demo?
+- What is novel, useful, or impressive about the approach?
+
+## design for feasibility
+
+A hackathon project should be scoped to finish. Define components and responsibilities before implementation.
+
+Good design choices:
+
+- Use a stack your team can move quickly in.
+- Prefer simple architecture over clever architecture.
+- Use abstraction only where it reduces confusion.
+- Keep communication tight.
+- Pick a deployment plan early.
+- Decide what the demo path will be before building too much.
+
+Vercel plus Supabase is a common quick stack for web apps, but use whatever your team knows well enough to ship.
+
+## implementation habits
+
+- Use version control from the start.
+- Prefer a monorepo unless there is a strong reason not to.
+- Document early so teammates and judges can understand the project.
+- Work in parallel, but integrate often.
+- Reserve time for the presentation.
+- Avoid scope creep.
+- Treat prototypes like experiments.
+
+The presentation is part of the product. A polished pitch can beat a slightly more complete project that judges cannot understand.
+
+## what to skip
+
+For a demo, no one is usually going to use your product at production scale. Skip low-value complexity unless it is central to the prompt.
+
+Usually skip:
+
+- Full authentication
+- Complex onboarding
+- Perfect settings pages
+- Overbuilt admin tools
+- Edge cases that will not appear in the demo
+- Infrastructure that does not support the story
+
+## using AI tools
+
+AI tools can help with debugging, scaffolding, design ideas, and unfamiliar APIs. Treat them like fast but imperfect assistants.
+
+Good AI use:
+
+- Ask for options, then choose intentionally.
+- Use AI to explain errors or unfamiliar libraries.
+- Generate boilerplate, then review it.
+- Use it to brainstorm edge cases.
+- Keep ownership of product direction and final code.
+
+Risky AI use:
+
+- Letting generated code define the whole product.
+- Accepting code you cannot explain.
+- Spending more time prompting than building.
+- Shipping insecure or broken code because it looked plausible.
+
+## judging and presentation
+
+A good final presentation answers:
+
+- What problem did you choose?
+- Who is the user?
+- What did you build?
+- Why is it useful or interesting?
+- What is technically impressive?
+- What did you learn or validate?
+- What would you do next?
+
+Show the happy path. If something is fragile, demo the part that works and explain the future plan honestly.
+

--- a/src/content/docs/Guides/Interview Prep.mdx
+++ b/src/content/docs/Guides/Interview Prep.mdx
@@ -1,0 +1,122 @@
+---
+title: Interview Prep
+description: Practical behavioral and technical interview advice from SoDA workshops.
+---
+
+Interviewing is a skill you can practice. SoDA's interview decks separate preparation into two tracks: behavioral interviews, where companies learn how you think and communicate, and technical interviews, where they assess problem solving and coding fundamentals.
+
+## behavioral interviews
+
+Behavioral interviews help companies understand:
+
+- Your value to the company
+- Whether you prepared
+- How you communicate
+- How you work with others
+- Whether your resume matches your story
+- How you react to conflict, ambiguity, pressure, or mistakes
+
+Common themes include teamwork, adaptability, leadership, strengths, weaknesses, communication, core values, hobbies, and career goals.
+
+## research before the interview
+
+Before an interview, learn:
+
+- What the company does
+- What products, customers, or industries it serves
+- Recent news, launches, or priorities
+- The exact role requirements
+- The company's values
+- What the company likely wants from interns or new grads
+
+Use that research to tailor your answers. A story about teamwork, for example, should highlight different details for a startup, a cloud infrastructure team, or a mission-driven nonprofit.
+
+## build a master intro
+
+Prepare a flexible `tell me about yourself` answer. It should cover:
+
+- Who you are
+- What you are studying
+- What experiences shaped your interests
+- What kind of work you are looking for
+- Why this role or company connects to that path
+
+Keep it concise. Think of it as a base template you can tailor, not a script to recite word-for-word.
+
+## use STAR stories
+
+STAR stands for Situation, Task, Action, Result.
+
+Situation: Give just enough background for the interviewer to understand the context.
+
+Task: Explain the challenge, responsibility, or goal.
+
+Action: Describe what you specifically did.
+
+Result: Close with the outcome, ideally with a measurable result or lesson learned.
+
+Prepare stories that can cover multiple prompts:
+
+- Teamwork
+- Leadership
+- Conflict
+- Innovation
+- Adaptability
+- Failure or dissatisfaction
+- Learning something quickly
+- Working with a difficult teammate
+
+## common behavioral questions
+
+- Tell me about yourself.
+- Why do you want to work here?
+- What are your career goals?
+- What is your biggest weakness?
+- What was your favorite CS class?
+- Tell me about a time you led a team.
+- Tell me about a time you handled conflict.
+- Tell me about a time you were dissatisfied with your work.
+- Explain a project from your resume.
+- What do you think our company does?
+
+## technical interview types
+
+Technical interviews may appear as:
+
+- Self-serve coding assessments
+- Phone screens with Google Docs, CoderPad, HackerRank, or similar tools
+- Video interviews with live coding
+- In-person whiteboard interviews
+- Project, system design, or take-home interviews for some roles
+
+## technical interview strategy
+
+- Clarify the problem before coding.
+- Ask about edge cases such as empty input, invalid input, duplicates, negative numbers, zero, and size bounds.
+- Start with a brute-force solution if needed.
+- Explain the brute-force runtime and what you can optimize.
+- Talk while you work so the interviewer can understand your reasoning.
+- Test your code with simple examples and edge cases.
+- If stuck, say what you know and ask a focused question.
+
+Interviewers usually want to see how you think. Silence makes it harder for them to help you.
+
+## how to practice
+
+- Practice early and consistently.
+- Solve problems without immediately searching for answers.
+- After solving, review the pattern and tradeoffs.
+- Practice in a plain editor, whiteboard, or shared document sometimes.
+- Use mock interviews with friends, clubs, Pramp, Interviewing.io, or similar tools.
+- Read `Cracking the Coding Interview` for fundamentals and common patterns.
+- Use LeetCode, HackerRank, CodingBat, NeetCode, Kaggle, or similar sites based on your target role.
+
+## final prep checklist
+
+- Can you explain every resume bullet?
+- Do you have at least five STAR stories ready?
+- Can you describe your strongest project in two minutes?
+- Have you researched the company and role?
+- Have you practiced coding out loud?
+- Do you have thoughtful questions for the interviewer?
+

--- a/src/content/docs/Guides/Resume and Career Prep.mdx
+++ b/src/content/docs/Guides/Resume and Career Prep.mdx
@@ -1,0 +1,148 @@
+---
+title: Resume and Career Prep
+description: Distilled SoDA advice on resumes, internships, applications, networking, and early career preparation.
+---
+
+This guide combines advice from SoDA resume workshops, career prep decks, and industry talks. The core message is simple: make it easy for a recruiter to understand what you can do, then create enough opportunities for that resume to be seen.
+
+## resume goals
+
+A strong CS resume should make these things obvious in a fast skim:
+
+- Who you are and how to contact you
+- What you are studying and when you graduate
+- What technical skills you can actually use
+- What projects, jobs, research, or leadership show those skills
+- What impact you had, not just what tasks you were assigned
+
+For most undergraduate recruiting, keep it to one page unless a specific application asks for something else.
+
+## header and personal info
+
+Include:
+
+- Name
+- Phone number
+- Professional email
+- City and state, usually `Tempe, Arizona` or wherever you are based
+- GitHub, portfolio, or LinkedIn if they help your case
+
+Avoid:
+
+- Full street address
+- Unprofessional email addresses
+- Long raw URLs
+- Objective or summary sections that repeat obvious information
+
+## education
+
+Include:
+
+- Arizona State University
+- Degree and major
+- Graduation month/year or expected graduation
+- GPA if it helps you, commonly if it is 3.0 or above
+- Relevant coursework only when it strengthens the target role
+
+High school usually should disappear once you have enough college experience, projects, or leadership to fill the page.
+
+## projects
+
+Projects are especially important when you do not have much work experience yet. A good project entry should show what you built, what technologies you used, what problem it solved, and what you learned.
+
+Useful project bullets answer:
+
+- What did the project do?
+- What was your specific contribution?
+- What tools, frameworks, APIs, or systems did you use?
+- What was the result or impact?
+- Is there a GitHub repo, demo, paper, or deployment to link?
+
+Course projects can count, but unique personal, team, open-source, research, or hackathon projects usually stand out more.
+
+## experience
+
+Experience does not have to be a software internship to be useful. TA roles, part-time jobs, research, club leadership, and nontechnical work can all show reliability, ownership, communication, and impact.
+
+Write bullets with active verbs and concrete outcomes:
+
+- Prefer `Built`, `Automated`, `Reduced`, `Improved`, `Led`, `Designed`, `Deployed`, or `Analyzed`.
+- Avoid vague openers like `Responsible for` or `My duties included`.
+- Show technologies in context instead of dumping buzzwords.
+- If possible, quantify impact with time saved, users supported, cost reduced, accuracy improved, or scope delivered.
+
+## skills
+
+The skills section should be short and easy to parse. Group related items when helpful:
+
+- Languages: Java, Python, TypeScript, C/C++
+- Frameworks: React, Node.js, Streamlit, FastAPI
+- Tools: Git, Docker, Linux, PostgreSQL
+- Cloud or AI tools if you have used them in real projects
+
+Do not label skills as beginner, intermediate, or advanced. If a skill is on the resume, be ready to talk about how you used it.
+
+## common resume mistakes
+
+- Exceeding one page for early-career recruiting
+- Using inconsistent dates, spacing, bullets, or alignment
+- Uploading a Word document when PDF is expected
+- Naming the file something like `final_company_x_resume.pdf`
+- Using too many colors or hard-to-read fonts
+- Repeating the same verb or same bullet structure everywhere
+- Listing projects you cannot explain clearly in an interview
+- Cramming every class, tool, and activity onto the page
+
+## how to get useful feedback
+
+Ask reviewers for specific passes instead of general thoughts:
+
+- `Can you do a 30-second recruiter skim and tell me what stands out?`
+- `Can you check grammar, spelling, and verb tense?`
+- `Can you tell me which bullets feel least relevant for this role?`
+- `Can you quiz me on every project or experience I listed?`
+- `Can you check whether the ordering matches this job description?`
+
+Do not follow advice blindly. Resume advice often conflicts, so ask why a change helps.
+
+## getting interviews
+
+The SoDA career decks frame the process as two steps: get the interview, then pass the interview. To get interviews:
+
+- Improve your resume before career fair season.
+- Practice a short elevator pitch.
+- Apply early when roles open.
+- Use LinkedIn, Handshake, company websites, and job boards.
+- Ask for referrals when you have a real connection.
+- Track applications in a spreadsheet.
+- Keep application details consistent, such as email and availability dates.
+
+For internships, early-career programs like STEP, Explore, and similar first-year or second-year programs can be worth applying to even if you are unsure you qualify.
+
+## internship alternatives
+
+If you do not land an internship yet, you can still build signal:
+
+- Become an undergraduate TA.
+- Do research with a professor or through FURI.
+- Work on open-source software.
+- Build and ship a personal project.
+- Attend hackathons.
+- Find a part-time campus or technical support role.
+- Contribute to club projects.
+
+The important thing is to keep creating evidence that you can learn, finish work, and collaborate.
+
+## tough market advice
+
+One industry talk emphasized that students should think beyond "I can code" and become problem solvers in real domains. AI, cloud, cybersecurity, data, MLOps, and backend systems matter, but they become more valuable when tied to real problems in healthcare, supply chain, sustainability, finance, education, nonprofits, or local businesses.
+
+Ways to stand out:
+
+- Build projects for real users or real organizations.
+- Attend hackathons with non-tech problem statements.
+- Volunteer technical skills for nonprofits.
+- Intern or work in non-tech companies that still need software.
+- Network with people in industries you are curious about and ask what problems they face.
+- Put measurable outcomes on your resume.
+

--- a/src/content/docs/Guides/SoDA Guide.mdx
+++ b/src/content/docs/Guides/SoDA Guide.mdx
@@ -1,0 +1,45 @@
+---
+title: What SoDA Is
+description: A quick guide to SoDA, what it offers, and how ASU CS students can get involved.
+---
+
+SoDA, the Software Developers Association, is a student-run software development community at ASU. Past intro decks describe it as a software development club for university students, but in practice it is also a place to find friends, projects, career help, technical workshops, and industry connections.
+
+## what SoDA does
+
+- Technical presentations and hands-on workshops
+- Industry networking events and recruiter visits
+- Resume reviews and resume-building advice
+- Mock behavioral and technical interviews
+- Job and internship opportunity sharing
+- Social events and community outreach
+- Bootcamps, code challenges, and hackathons
+
+## why show up
+
+- You meet other CS students before you need help on a project or class.
+- You get exposed to tools ASU classes may not cover deeply, such as Git, APIs, deployment, and interview prep.
+- You can ask for resume feedback from people who have already gone through recruiting.
+- You can build a track record outside coursework through projects, hackathons, and leadership.
+- You get more chances to talk with industry professionals in lower-pressure settings.
+
+## how to get involved
+
+- Attend general meetings and workshops when they match your interests.
+- Join the current community chat linked from SoDA's website or social media.
+- Follow event announcements so you know when resume reviews, mock interviews, industry talks, and hackathons are happening.
+- Volunteer at events or apply for organizer roles if you want leadership experience.
+- Bring friends. Clubs are easier to stick with when you make them part of your routine.
+
+## good first events
+
+- Resume review nights if you are preparing for career fairs.
+- Intro Git workshops if you have mostly coded alone.
+- Technical interview prep if you are applying for internships.
+- Hackathon info sessions if you want a structured reason to build something.
+- Industry talks if you want to understand what real software roles look like.
+
+## what to remember
+
+SoDA is most useful when you treat it as an active community, not just an announcement feed. Talk to people, ask questions, bring projects you are stuck on, and use events as deadlines to keep improving.
+

--- a/src/content/docs/Guides/Workshop Notes.mdx
+++ b/src/content/docs/Guides/Workshop Notes.mdx
@@ -1,0 +1,45 @@
+---
+title: SoDA Workshop Notes
+description: Distilled notes from SoDA presentations, workshops, and info sessions.
+---
+
+SoDA has run a lot of useful workshops over the years. This section turns those slide decks into wiki-friendly notes you can skim before career fairs, hackathons, interviews, or side projects.
+
+These pages are not exact transcripts. They are distilled from past SoDA presentations so the advice is easier to reuse.
+
+## quick links
+
+- [What SoDA is and how to get involved](/guides/soda-guide)
+- [Resume and career prep](/guides/resume-and-career-prep)
+- [Behavioral and technical interview prep](/guides/interview-prep)
+- [Git and GitHub](/guides/git-and-github)
+- [Hackathons](/guides/hackathons)
+- [AI and LLM projects](/guides/ai-and-llm-projects)
+- [Functional programming](/guides/functional-programming)
+
+## source decks covered
+
+- `What is SoDA and can I drink it.pdf`
+- `8_31_2021 _What is soda and can I drink it_.pdf`
+- `GBM #2 Resume Workshop Presentation.pdf`
+- `Resume Reviews.pdf`
+- `9_7 Resume Reviews.pdf`
+- `Jumpstart your Career!.pdf`
+- `Behavioral Interview Workshop.pdf`
+- `Technical Interview Prep.pdf`
+- `Gitting Started with Git.pdf`
+- `Intro_to_Git.pptx`
+- `Intro_to_Git_Pt2.pptx.pdf`
+- `How to prepare for the spring.pptx.pdf`
+- `InnovationHacks Info Session.pdf`
+- `LLM API Workshop.pdf`
+- `Amazon-3_18-Presentation.pdf`
+- `Functional Programming.pdf`
+
+## how to use these notes
+
+- If you are new to ASU CS, start with [What SoDA is and how to get involved](/guides/soda-guide), then [Git and GitHub](/guides/git-and-github).
+- If career fair season is coming up, start with [Resume and career prep](/guides/resume-and-career-prep), then [Behavioral and technical interview prep](/guides/interview-prep).
+- If you are building a project, start with [Hackathons](/guides/hackathons) and [AI and LLM projects](/guides/ai-and-llm-projects).
+- If you want to level up how you think about code, read [Functional programming](/guides/functional-programming).
+

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -38,6 +38,12 @@ import { ContributorList } from "starlight-contributor-list";
 		description="Some wisdom on internships, resume tips/templates, and how to nail your interviews."
 	/>
 	<IconLinkCard
+		title="Workshop Notes"
+		icon="document"
+		href="/guides/workshop-notes"
+		description="Distilled notes from SoDA workshops on resumes, interviews, Git, hackathons, AI projects, and more."
+	/>
+	<IconLinkCard
 		title="Clubs"
 		icon="comment"
 		href="/guides/clubs"


### PR DESCRIPTION
Add a set of new SoDA guide pages (AI and LLM Projects, Functional Programming, Git and GitHub, Hackathons, Interview Prep, Resume and Career Prep, What SoDA Is) plus a Workshop Notes index page. Also update docs index to surface the Workshop Notes card. These pages distill workshop decks and practical advice for students (career prep, hackathons, Git, AI projects, functional ideas, etc.).

## Description
Brief description of the changes

## Type of Change
- [ ] Content update (course info, guides, resources)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
- [ ] Tested locally
- [ ] Verified all links work
- [ ] Checked mobile responsiveness (if applicable)

## Screenshots (if applicable)
Add screenshots here

## Additional Notes
Any additional information or context