### PR TITLE
Replace outdated Windsurf student plan with Kiro

### DIFF
--- a/src/content/docs/Guides/Maximizing Free AI as ASU Student.mdx
+++ b/src/content/docs/Guides/Maximizing Free AI as ASU Student.mdx
@@ -28,9 +28,9 @@ Being a student at ASU comes with a surprising number of free premium AI subscri
     - There's also a bunch of other cool things you can get with the pack. Scroll through and shop around!
 - **Cursor via [cursor.com/students](https://cursor.com/students)**
     - Free Pro for a year with a `.edu` email
-- **Windsurf via [windsurf.com/editor/students](https://windsurf.com/editor/students)**
-    - AI-powered code editor with a free tier (25 credits/month)
-    - Students get over 50% off a Pro subscription with a `.edu` email
+- **Kiro via [kiro.dev/students](https://kiro.dev/students/)**
+    - AWS's AI-powered code editor (IDE and CLI)
+    - Free plan available for ASU students
 - **Zed via [zed.dev/education](https://zed.dev/education)**
     - Free Pro for one year for verified university students
     - Includes $10/month in token credits for AI assistance, unlimited edit predictions, and real-time multiplayer collaboration


### PR DESCRIPTION
## Description
Swaps the Windsurf entry in the "Maximizing Free AI as ASU Student" guide for Kiro, AWS's AI-powered code editor (IDE and CLI). Windsurf's student plan is no longer available, while Kiro now offers a free plan for ASU students at kiro.dev/students.

## Type of Change
- [x] Content update (course info, guides, resources)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
- [x] Verified all links work
- [ ] Tested locally
- [ ] Checked mobile responsiveness (if applicable)

## Screenshots (if applicable)
N/A

## Additional Notes
Reported by a former ASU CS student who noticed the outdated info while browsing the wiki.